### PR TITLE
Add sendto() to list of permitted system calls if NERSC mods are active.

### DIFF
--- a/openssh-6.6p1-hpn14v5/sandbox-seccomp-filter.c
+++ b/openssh-6.6p1-hpn14v5/sandbox-seccomp-filter.c
@@ -119,6 +119,9 @@ static const struct sock_filter preauth_insns[] = {
 	SC_ALLOW(exit_group),
 #ifdef NERSC_MOD
 	SC_ALLOW(sendto),
+	SC_ALLOW(stat),
+	SC_ALLOW(socket),
+	SC_ALLOW(connect),
 #endif
 #ifdef __NR_rt_sigprocmask
 	SC_ALLOW(rt_sigprocmask),

--- a/openssh-6.6p1-hpn14v5/sandbox-seccomp-filter.c
+++ b/openssh-6.6p1-hpn14v5/sandbox-seccomp-filter.c
@@ -117,6 +117,9 @@ static const struct sock_filter preauth_insns[] = {
 #endif
 	SC_ALLOW(munmap),
 	SC_ALLOW(exit_group),
+#ifdef NERSC_MOD
+	SC_ALLOW(sendto),
+#endif
 #ifdef __NR_rt_sigprocmask
 	SC_ALLOW(rt_sigprocmask),
 #else


### PR DESCRIPTION
This fixes the issue we've been talking about.  It was actually the sendto() system call that needed to be added.  :-)
